### PR TITLE
j2 indenting to correct for multiple lighthouse nodes

### DIFF
--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -124,9 +124,9 @@ firewall:
       {% if rule.host is defined %}host: "{{ rule.host }}"
       {% elif rule.group is defined %}group: "{{ rule.group }}"
       {% elif rule.groups is defined %}groups:
-        {% for group in rule.groups %}
+      {% for group in rule.groups %}
         - {{ group }}
-        {% endfor %}
+      {% endfor %}
       {% elif rule.cidr is defined %}cidr: {{ rule.cidr }}
       {% else %}
       host: any
@@ -141,9 +141,9 @@ firewall:
       {% if rule.host is defined %}host: "{{ rule.host }}"
       {% elif rule.group is defined %}group: "{{ rule.group }}"
       {% elif rule.groups is defined %}groups:
-        {% for group in rule.groups %}
+      {% for group in rule.groups %}
         - {{ group }}
-        {% endfor %}
+      {% endfor %}
       {% elif rule.cidr is defined %}cidr: {{ rule.cidr }}
       {% else %}
       host: any

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -25,10 +25,10 @@ lighthouse:
   hosts:
 {% if lighthouse.am_lighthouse is not defined %}
 {% for host in lighthouses %}
-  {% if host.nebula_ip is defined %}
+{% if host.nebula_ip is defined %}
   - "{{ host.nebula_ip }}"
-  {% endif %}
-  {% endfor %}
+{% endif %}
+{% endfor %}
 {% endif %}
 
 listen:


### PR DESCRIPTION
This corrects an issue I encountered where having more than one lighthouse node specified results in malformed yaml in config file for the non-lighthouse nodes.

Subsequent lighthouse node IPs would be indented too far.  I have witnessed similar behavior in J2 templates before, and conditional block indent needs to be adjusted.