### PR TITLE
Make nebula bin configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,3 +51,5 @@ inbound:
   - port: any
     proto: icmp
     host: any
+
+nebula_bin_location: /bin

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,9 @@ nebula_bin_directory: /bin
 # location of the nebula binaries
 nebula_bin_directory: /bin
 
+# location of the nebula binaries
+nebula_bin_directory: /bin
+
 # this will cause net.ipv4.ip_forward to be set to 1 to allow unsafe routes
 enable_ip_forward: false
 
@@ -57,5 +60,3 @@ inbound:
   - port: any
     proto: icmp
     host: any
-
-nebula_bin_directory: /bin

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,9 @@ nebula_force_install: false
 # location of the nebula binaries
 nebula_bin_directory: /bin
 
+# location of the nebula binaries
+nebula_bin_directory: /bin
+
 # this will cause net.ipv4.ip_forward to be set to 1 to allow unsafe routes
 enable_ip_forward: false
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,5 +51,3 @@ inbound:
   - port: any
     proto: icmp
     host: any
-
-nebula_bin_directory: /bin

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -58,4 +58,4 @@ inbound:
     proto: icmp
     host: any
 
-nebula_bin_location: /bin
+nebula_bin_directory: /bin

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,4 +49,4 @@ inbound:
     proto: icmp
     host: any
 
-nebula_bin_location: /bin
+nebula_bin_directory: /bin

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,9 @@
 # defaults file for .
 nebula_version: 1.3.0
 
+# location of the nebula binaries
+nebula_bin_directory: /bin
+
 # this will cause net.ipv4.ip_forward to be set to 1 to allow unsafe routes
 enable_ip_forward: false
 
@@ -48,5 +51,3 @@ inbound:
   - port: any
     proto: icmp
     host: any
-
-nebula_bin_directory: /bin

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,9 @@ nebula_version: 1.5.0
 # force overwrite
 nebula_force_install: false
 
+# location of the nebula binaries
+nebula_bin_directory: /bin
+
 # this will cause net.ipv4.ip_forward to be set to 1 to allow unsafe routes
 enable_ip_forward: false
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,3 +48,5 @@ inbound:
   - port: any
     proto: icmp
     host: any
+
+nebula_bin_location: /bin

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,9 @@
 # defaults file for .
 nebula_version: 1.3.0
 
+# location of the nebula binaries
+nebula_bin_directory: /bin
+
 # this will cause net.ipv4.ip_forward to be set to 1 to allow unsafe routes
 enable_ip_forward: false
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -55,4 +55,4 @@ inbound:
     proto: icmp
     host: any
 
-nebula_bin_location: /bin
+nebula_bin_directory: /bin

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,5 +54,3 @@ inbound:
   - port: any
     proto: icmp
     host: any
-
-nebula_bin_directory: /bin

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,3 +57,5 @@ inbound:
   - port: any
     proto: icmp
     host: any
+
+nebula_bin_location: /bin

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,15 +8,6 @@ nebula_force_install: false
 # location of the nebula binaries
 nebula_bin_directory: /bin
 
-# location of the nebula binaries
-nebula_bin_directory: /bin
-
-# location of the nebula binaries
-nebula_bin_directory: /bin
-
-# location of the nebula binaries
-nebula_bin_directory: /bin
-
 # this will cause net.ipv4.ip_forward to be set to 1 to allow unsafe routes
 enable_ip_forward: false
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,4 +52,4 @@ inbound:
     proto: icmp
     host: any
 
-nebula_bin_location: /bin
+nebula_bin_directory: /bin

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,3 +54,5 @@ inbound:
   - port: any
     proto: icmp
     host: any
+
+nebula_bin_location: /bin

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,33 +11,33 @@
 - name: Download release from Github (x86)
   unarchive:
     src: https://github.com/slackhq/nebula/releases/download/v{{ nebula_version }}/nebula-{{ ansible_system|lower }}-amd64.tar.gz
-    dest: /bin
+    dest: "{{ nebula_bin_directory }}"
     remote_src: yes
     mode: 0755
-    creates: /bin/nebula
+    creates: "{{ nebula_bin_directory }}/nebula"
   when: ansible_architecture == "x86_64"
 
 - name: Download release from Github (arm64)
   unarchive:
     src: https://github.com/slackhq/nebula/releases/download/v{{ nebula_version }}/nebula-{{ ansible_system|lower }}-arm64.tar.gz
-    dest: /bin
+    dest: {{ nebula_bin_directory }}
     remote_src: yes
     mode: 0755
-    creates: /bin/nebula
+    creates: "{{ nebula_bin_directory }}/nebula"
   when: ansible_architecture == "armv64" or ansible_architecture == "aarch64"
 
 - name: Download release from Github (arm7)
   unarchive:
     src: https://github.com/slackhq/nebula/releases/download/v{{ nebula_version }}/nebula-{{ ansible_system|lower }}-arm-7.tar.gz
-    dest: /bin
+    dest: {{ nebula_bin_directory }}
     remote_src: yes
     mode: 0755
-    creates: /bin/nebula
+    creates: "{{ nebula_bin_directory }}/nebula"
   when: ansible_architecture == "armv7l"
 
 - name: Set correct user and group on the nebula binary
   ansible.builtin.file:
-    path: /bin/nebula
+    path: "{{ nebula_bin_directory }}/nebula"
     owner: root
     group: root
     mode: '0750'
@@ -60,7 +60,7 @@
     - Restart_nebula
 
 - name: Verify configuration
-  ansible.builtin.command: /bin/nebula -test -config /etc/nebula/config.yaml 1>/dev/null
+  ansible.builtin.command: "{{ nebula_bin_directory }}/nebula -test -config /etc/nebula/config.yaml 1>/dev/null"
   changed_when: false
 
 - name: Deploy systemd template

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,6 +47,13 @@
     group: root
     mode: '0750'
 
+- name: Set correct user and group on the nebula-cert binary
+  ansible.builtin.file:
+    path: "{{ nebula_bin_directory }}/nebula-cert"
+    owner: root
+    group: root
+    mode: '0750'
+
 - name: Create configuration directory
   file:
     path: /etc/nebula

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,6 +35,7 @@
   unarchive:
     src: https://github.com/slackhq/nebula/releases/download/v{{ nebula_version }}/nebula-{{ ansible_system|lower }}-arm-7.tar.gz
     dest: "{{ nebula_bin_directory }}"
+
     remote_src: yes
     mode: 0755
     creates: "{{ nebula_bin_directory }}/nebula"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,7 +35,6 @@
   unarchive:
     src: https://github.com/slackhq/nebula/releases/download/v{{ nebula_version }}/nebula-{{ ansible_system|lower }}-arm-7.tar.gz
     dest: "{{ nebula_bin_directory }}"
-
     remote_src: yes
     mode: 0755
     creates: "{{ nebula_bin_directory }}/nebula"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,36 +8,48 @@
   notify:
     - Restart_nebula
 
+- name: Ensure nebula bin directory exists
+  file:
+    path: "{{ nebula_bin_directory }}"
+    state: directory
+
 - name: Download release from Github (x86)
   unarchive:
     src: https://github.com/slackhq/nebula/releases/download/v{{ nebula_version }}/nebula-{{ ansible_system|lower }}-amd64.tar.gz
-    dest: /bin
+    dest: "{{ nebula_bin_directory }}"
     remote_src: yes
     mode: 0755
-    creates: /bin/nebula
+    creates: "{{ nebula_bin_directory }}/nebula"
   when: ansible_architecture == "x86_64"
 
 - name: Download release from Github (arm64)
   unarchive:
     src: https://github.com/slackhq/nebula/releases/download/v{{ nebula_version }}/nebula-{{ ansible_system|lower }}-arm64.tar.gz
-    dest: /bin
+    dest: "{{ nebula_bin_directory }}"
     remote_src: yes
     mode: 0755
-    creates: /bin/nebula
+    creates: "{{ nebula_bin_directory }}/nebula"
   when: ansible_architecture == "armv64" or ansible_architecture == "aarch64"
 
 - name: Download release from Github (arm7)
   unarchive:
     src: https://github.com/slackhq/nebula/releases/download/v{{ nebula_version }}/nebula-{{ ansible_system|lower }}-arm-7.tar.gz
-    dest: /bin
+    dest: "{{ nebula_bin_directory }}"
     remote_src: yes
     mode: 0755
-    creates: /bin/nebula
+    creates: "{{ nebula_bin_directory }}/nebula"
   when: ansible_architecture == "armv7l"
 
 - name: Set correct user and group on the nebula binary
   ansible.builtin.file:
-    path: /bin/nebula
+    path: "{{ nebula_bin_directory }}/nebula"
+    owner: root
+    group: root
+    mode: '0750'
+
+- name: Set correct user and group on the nebula-cert binary
+  ansible.builtin.file:
+    path: "{{ nebula_bin_directory }}/nebula-cert"
     owner: root
     group: root
     mode: '0750'
@@ -60,7 +72,7 @@
     - Restart_nebula
 
 - name: Verify configuration
-  ansible.builtin.command: /bin/nebula -test -config /etc/nebula/config.yaml 1>/dev/null
+  ansible.builtin.command: "{{ nebula_bin_directory }}/nebula -test -config /etc/nebula/config.yaml 1>/dev/null"
   changed_when: false
 
 - name: Deploy systemd template

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,7 +52,7 @@
     path: "{{ nebula_bin_directory }}/nebula-cert"
     owner: root
     group: root
-    mode: "0750"
+    mode: '0750'
 
 - name: Create configuration directory
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,8 @@
   file:
     path: "{{ nebula_bin_directory }}"
     state: directory
+    owner: root
+    group: root
 
 - name: Download release from Github (x86)
   unarchive:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,36 +8,48 @@
   notify:
     - Restart_nebula
 
+- name: Ensure nebula bin directory exists
+  file:
+    path: "{{ nebula_bin_directory }}"
+    state: directory
+
 - name: Download release from Github (x86)
   unarchive:
     src: https://github.com/slackhq/nebula/releases/download/v{{ nebula_version }}/nebula-{{ ansible_system|lower }}-amd64.tar.gz
-    dest: /bin
+    dest: "{{ nebula_bin_directory }}"
     remote_src: yes
     mode: 0755
-    creates: "{{ '/bin/nebula' if nebula_force_install == false else '' }}"
+    creates: "{{ (nebula_bin_directory + '/nebula') if nebula_force_install == false else '' }}"
   when: ansible_architecture == "x86_64"
 
 - name: Download release from Github (arm64)
   unarchive:
     src: https://github.com/slackhq/nebula/releases/download/v{{ nebula_version }}/nebula-{{ ansible_system|lower }}-arm64.tar.gz
-    dest: /bin
+    dest: "{{ nebula_bin_directory }}"
     remote_src: yes
     mode: 0755
-    creates: "{{ '/bin/nebula' if nebula_force_install == false else '' }}"
+    creates: "{{ (nebula_bin_directory + '/nebula') if nebula_force_install == false else '' }}"
   when: ansible_architecture == "armv64" or ansible_architecture == "aarch64"
 
 - name: Download release from Github (arm7)
   unarchive:
     src: https://github.com/slackhq/nebula/releases/download/v{{ nebula_version }}/nebula-{{ ansible_system|lower }}-arm-7.tar.gz
-    dest: /bin
+    dest: "{{ nebula_bin_directory }}"
     remote_src: yes
     mode: 0755
-    creates: "{{ '/bin/nebula' if nebula_force_install == false else '' }}"
+    creates: "{{ (nebula_bin_directory + '/nebula') if nebula_force_install == false else '' }}"
   when: ansible_architecture == "armv7l"
 
 - name: Set correct user and group on the nebula binary
   ansible.builtin.file:
-    path: /bin/nebula
+    path: "{{ nebula_bin_directory }}/nebula"
+    owner: root
+    group: root
+    mode: '0750'
+
+- name: Set correct user and group on the nebula-cert binary
+  ansible.builtin.file:
+    path: "{{ nebula_bin_directory }}/nebula-cert"
     owner: root
     group: root
     mode: "0750"
@@ -60,7 +72,7 @@
     - Restart_nebula
 
 - name: Verify configuration
-  ansible.builtin.command: /bin/nebula -test -config /etc/nebula/config.yaml 1>/dev/null
+  ansible.builtin.command: "{{ nebula_bin_directory }}/nebula -test -config /etc/nebula/config.yaml 1>/dev/null"
   changed_when: false
 
 - name: Deploy systemd template

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,7 +35,6 @@
   unarchive:
     src: https://github.com/slackhq/nebula/releases/download/v{{ nebula_version }}/nebula-{{ ansible_system|lower }}-arm-7.tar.gz
     dest: "{{ nebula_bin_directory }}"
-
     remote_src: yes
     mode: 0755
     creates: "{{ (nebula_bin_directory + '/nebula') if nebula_force_install == false else '' }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,13 @@
   notify:
     - Restart_nebula
 
+- name: Ensure nebula bin directory exists
+  file:
+    path: "{{ nebula_bin_directory }}"
+    state: directory
+    owner: root
+    group: root
+
 - name: Download release from Github (x86)
   unarchive:
     src: https://github.com/slackhq/nebula/releases/download/v{{ nebula_version }}/nebula-{{ ansible_system|lower }}-amd64.tar.gz

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,6 +35,7 @@
   unarchive:
     src: https://github.com/slackhq/nebula/releases/download/v{{ nebula_version }}/nebula-{{ ansible_system|lower }}-arm-7.tar.gz
     dest: "{{ nebula_bin_directory }}"
+
     remote_src: yes
     mode: 0755
     creates: "{{ (nebula_bin_directory + '/nebula') if nebula_force_install == false else '' }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,7 +20,7 @@
 - name: Download release from Github (arm64)
   unarchive:
     src: https://github.com/slackhq/nebula/releases/download/v{{ nebula_version }}/nebula-{{ ansible_system|lower }}-arm64.tar.gz
-    dest: {{ nebula_bin_directory }}
+    dest: "{{ nebula_bin_directory }}"
     remote_src: yes
     mode: 0755
     creates: "{{ nebula_bin_directory }}/nebula"
@@ -29,7 +29,7 @@
 - name: Download release from Github (arm7)
   unarchive:
     src: https://github.com/slackhq/nebula/releases/download/v{{ nebula_version }}/nebula-{{ ansible_system|lower }}-arm-7.tar.gz
-    dest: {{ nebula_bin_directory }}
+    dest: "{{ nebula_bin_directory }}"
     remote_src: yes
     mode: 0755
     creates: "{{ nebula_bin_directory }}/nebula"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,8 +12,6 @@
   file:
     path: "{{ nebula_bin_directory }}"
     state: directory
-    owner: root
-    group: root
 
 - name: Download release from Github (x86)
   unarchive:

--- a/templates/nebula.service.j2
+++ b/templates/nebula.service.j2
@@ -8,7 +8,7 @@ SyslogIdentifier=nebula
 StandardOutput=syslog
 StandardError=syslog
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStart=/bin/nebula -config /etc/nebula/config.yaml
+ExecStart={{ nebula_bin_directory }}/nebula -config /etc/nebula/config.yaml
 Restart=always
 
 [Install]

--- a/templates/nebula.service.j2
+++ b/templates/nebula.service.j2
@@ -8,7 +8,7 @@ SyslogIdentifier=nebula
 StandardOutput=syslog
 StandardError=syslog
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStart={{ nebula_bin_directory }}nebula -config /etc/nebula/config.yaml
+ExecStart={{ nebula_bin_directory }}/nebula -config /etc/nebula/config.yaml
 Restart=always
 
 [Install]

--- a/templates/nebula.service.j2
+++ b/templates/nebula.service.j2
@@ -8,7 +8,7 @@ SyslogIdentifier=nebula
 StandardOutput=syslog
 StandardError=syslog
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStart=/bin/nebula -config /etc/nebula/config.yaml
+ExecStart={{ nebula_bin_directory }}nebula -config /etc/nebula/config.yaml
 Restart=always
 
 [Install]


### PR DESCRIPTION
Makes the location of the Nebula binaries configurable for those that want to place them in /opt or wherever else.  Sets the default to /bin so that no breaking changes are made.