### PR TITLE
fix jinja templating of config so it renders valid yaml

### DIFF
--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -1,3 +1,4 @@
+# {{ ansible_managed }}
 pki:
   # The CAs that are accepted by this node. Must contain one or more certificates created by 'nebula-cert ca'
   ca: {{ pki.ca }}
@@ -164,16 +165,20 @@ firewall:
 {% for rule in outbound %}
     - port: "{{ rule.port }}"
       proto: "{{ rule.proto }}"
-      {% if rule.host is defined %}host: "{{ rule.host }}"
-      {% elif rule.group is defined %}group: "{{ rule.group }}"
-      {% elif rule.groups is defined %}groups:
-      {% for group in rule.groups %}
+{% if rule.host is defined %}
+      host: "{{ rule.host }}"
+{% elif rule.group is defined %}
+      group: "{{ rule.group }}"
+{% elif rule.groups is defined %}
+      groups:
+{% for group in rule.groups %}
         - {{ group }}
-      {% endfor %}
-      {% elif rule.cidr is defined %}cidr: {{ rule.cidr }}
-      {% else %}
+{% endfor %}
+{% elif rule.cidr is defined %}
+      cidr: {{ rule.cidr }}
+{% else %}
       host: any
-      {% endif %}
+{% endif %}
 {% endfor %}
 
 
@@ -190,7 +195,8 @@ firewall:
 {% for group in rule.groups %}
         - {{ group }}
 {% endfor %}
-{% elif rule.cidr is defined %}cidr: {{ rule.cidr }}
+{% elif rule.cidr is defined %}
+      cidr: {{ rule.cidr }}
 {% else %}
       host: any
 {% endif %}


### PR DESCRIPTION
The firewall rule templating had indentation issues due to jinja tags.

An example of firewall rules that were rendered that are not valid yaml:
```
  inbound:
    - port: "any"
      proto: "icmp"
      host: "any"
    - port: "22"
      proto: "tcp"
cidr: 192.168.0.0/24
    - port: "53"
      proto: "any"
      host: "any"
```